### PR TITLE
Allow zoom using scroll wheel on macOS

### DIFF
--- a/Sources/CropImage/UnderlyingImageView.swift
+++ b/Sources/CropImage/UnderlyingImageView.swift
@@ -25,6 +25,7 @@ struct UnderlyingImageView: View {
     @State private var tempOffset: CGSize = .zero
     @State private var tempScale: CGFloat = 1
     @State private var tempRotation: Angle = .zero
+    @State private var scrolling: Bool = false
     #if os(macOS)
     @State private var isHovering: Bool = false
     #endif
@@ -69,9 +70,15 @@ struct UnderlyingImageView: View {
         clampedOffset.height = clampedOffset.height.clamped(to: yOffsetBounds(at: clampedScale))
 
         if clampedScale != scale || clampedOffset != offset {
-            withAnimation(.interactiveSpring()) {
+            if scrolling {
                 scale = clampedScale
                 offset = clampedOffset
+                scrolling = false
+            } else {
+                withAnimation(.interactiveSpring()) {
+                    scale = clampedScale
+                    offset = clampedOffset
+                }
             }
         }
     }
@@ -88,6 +95,7 @@ struct UnderlyingImageView: View {
         #if os(macOS)
         NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) {event in
             if isHovering {
+                scrolling = true
                 scale = scale + event.scrollingDeltaY/1000
             }
             return event

--- a/Sources/CropImage/UnderlyingImageView.swift
+++ b/Sources/CropImage/UnderlyingImageView.swift
@@ -81,6 +81,15 @@ struct UnderlyingImageView: View {
         scale = min(widthScale, heightScale)
     }
 
+    private func setupScrollMonitor() {
+        #if os(macOS)
+        NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) {event in
+            scale = scale + event.scrollingDeltaY/1000
+            return event
+        }
+        #endif
+    }
+
     var imageView: Image {
 #if os(macOS)
         Image(nsImage: image)
@@ -94,6 +103,9 @@ struct UnderlyingImageView: View {
             .gesture(dragGesture)
             .gesture(magnificationgesture)
             .gesture(rotationGesture)
+            .onAppear {
+                setupScrollMonitor()
+            }
     }
 
     var dragGesture: some Gesture {

--- a/Sources/CropImage/UnderlyingImageView.swift
+++ b/Sources/CropImage/UnderlyingImageView.swift
@@ -25,6 +25,9 @@ struct UnderlyingImageView: View {
     @State private var tempOffset: CGSize = .zero
     @State private var tempScale: CGFloat = 1
     @State private var tempRotation: Angle = .zero
+    #if os(macOS)
+    @State private var isHovering: Bool = false
+    #endif
 
     // When rotated odd multiples of 90 degrees, we need to switch width and height of the image in calculations.
     var isRotatedOddMultiplesOf90Deg: Bool {
@@ -84,7 +87,9 @@ struct UnderlyingImageView: View {
     private func setupScrollMonitor() {
         #if os(macOS)
         NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) {event in
-            scale = scale + event.scrollingDeltaY/1000
+            if isHovering {
+                scale = scale + event.scrollingDeltaY/1000
+            }
             return event
         }
         #endif
@@ -160,6 +165,11 @@ struct UnderlyingImageView: View {
             .onChange(of: rotation) { _ in
                 adjustToFulfillTargetFrame()
             }
+            #if os(macOS)
+            .onHover { hovering in
+                isHovering = hovering
+            }
+            #endif
     }
 }
 


### PR DESCRIPTION
I realised that there is no way to zoom in/out when using a traditional mouse with scroll wheel on macOS. This PR enables the scroll wheel to zoom in and out of the image.